### PR TITLE
Fix order data fetching after payment

### DIFF
--- a/Archphaze/src/components/Success.jsx
+++ b/Archphaze/src/components/Success.jsx
@@ -1,15 +1,49 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 
 export default function Success() {
   const [params] = useSearchParams();
   const sessionId = params.get('session_id');
+  const [status, setStatus] = useState('idle'); // idle | confirming | confirmed | error
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function confirm() {
+      if (!sessionId) return;
+      try {
+        setStatus('confirming');
+        const res = await fetch('http://localhost:3000/backend/payment/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId }),
+        });
+        const data = await res.json();
+        if (!res.ok || data?.error) throw new Error(data?.error || 'Failed to confirm payment');
+        if (!cancelled) setStatus('confirmed');
+      } catch (e) {
+        if (!cancelled) {
+          setStatus('error');
+          setError(e.message || 'Failed to finalize order.');
+        }
+      }
+    }
+    confirm();
+    return () => { cancelled = true; };
+  }, [sessionId]);
+
   return (
     <div className="max-w-3xl mx-auto py-20 px-6 text-center">
       <h1 className="text-3xl font-bold mb-4">Payment Successful</h1>
       <p className="text-gray-700">Thank you! Your payment was completed.</p>
       {sessionId && (
         <p className="text-xs text-gray-500 mt-2">Session: {sessionId}</p>
+      )}
+      {status === 'confirming' && (
+        <p className="text-sm text-gray-500 mt-3">Finalizing your order…</p>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-600 mt-3">{error}</p>
       )}
       <div className="mt-6 flex gap-3 justify-center">
         <Link to="/orderhistory" className="inline-block text-white bg-black px-4 py-2 rounded">View Order History</Link>

--- a/Archphaze/src/shop/Checkout.jsx
+++ b/Archphaze/src/shop/Checkout.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { useLocation, Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 function getImageUrl(imagePath) {
   if (!imagePath) return "/logo.webp";
@@ -19,6 +20,8 @@ export default function Checkout() {
     couponDiscount = 0,
     totalPrice: passedTotal = 0,
   } = state || {};
+
+  const currentUser = useSelector((s) => s.user?.currentUser);
 
   const computedTotal = useMemo(() => {
     if (selectedProducts.length > 0) {
@@ -71,12 +74,18 @@ export default function Checkout() {
       productId: String(item.productId || "").trim(),
     }));
 
+    const payload = {
+      products,
+      userId: currentUser?._id || currentUser?.id || undefined,
+      email: currentUser?.email || undefined,
+    };
+
     setSubmitting(true);
     try {
       const response = await fetch("http://localhost:3000/backend/payment/create-checkout-session", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ products }),
+        body: JSON.stringify(payload),
       });
 
       const data = await response.json();

--- a/Backend/models/order.model.js
+++ b/Backend/models/order.model.js
@@ -24,6 +24,7 @@ const orderSchema = new mongoose.Schema({
   totalAmount: { type: Number, required: true }, // in paisa
   status: { type: String, enum: ['pending', 'paid', 'fulfilled', 'canceled'], default: 'paid' },
   stripeSessionId: { type: String, required: true, index: true },
+  userId: { type: String, index: true },
   customer: {
     name: String,
     email: String,

--- a/Backend/routes/order.route.js
+++ b/Backend/routes/order.route.js
@@ -17,13 +17,18 @@ router.get('/supplier/:supplierId', async (req, res) => {
   }
 });
 
-// Fetch orders for the logged-in user by their email
+// Fetch orders for the logged-in user by their email or userId
 router.get('/user/me', verifyToken, async (req, res) => {
   try {
     const user = await User.findById(req.user.id).lean();
     if (!user) return res.status(404).json({ error: 'User not found' });
 
-    const orders = await Order.find({ 'customer.email': user.email }).sort({ createdAt: -1 });
+    const orders = await Order.find({
+      $or: [
+        { userId: req.user.id },
+        { 'customer.email': user.email },
+      ],
+    }).sort({ createdAt: -1 });
     res.json({ orders });
   } catch (err) {
     console.error('Error fetching user orders:', err);


### PR DESCRIPTION
Implement robust order creation and fetching after Stripe payments to ensure all user roles can view orders reliably.

Previously, orders were solely created via Stripe webhooks. This caused issues in local/dev environments or if webhook delivery failed, as no orders would be recorded. Additionally, user order fetching relied only on `customer.email`, which could be inconsistent. This PR introduces a fallback `/confirm` endpoint called from the success page, adds `userId` to orders, and improves user order lookup, ensuring orders are always created and visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-74090ce1-0030-46b3-b29e-bc16f2b05d1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74090ce1-0030-46b3-b29e-bc16f2b05d1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

