### PR TITLE
Change to manual variant selection

### DIFF
--- a/Archphaze/src/shop/Productdetail.jsx
+++ b/Archphaze/src/shop/Productdetail.jsx
@@ -62,13 +62,8 @@ export default function ProductPage() {
         setSelectedProduct(data);
         setSelectedImage(data.images?.[0] || "");
 
-        // Setup initial variant images
-        const initialVariantImages = {};
-        data.variants?.forEach((variant, idx) => {
-          const rawImage = variant.images?.[0] || "";
-          initialVariantImages[idx] = getProductImageUrl(rawImage);
-        });
-        setSelectedVariantImages(initialVariantImages);
+        // Do not preselect variant images; require manual selection by user
+        setSelectedVariantImages({});
       } catch (err) {
         setError(err.message);
       } finally {
@@ -109,6 +104,16 @@ export default function ProductPage() {
 
     if (!selectedProduct || selectedProduct.stock === 0) return;
 
+    // Ensure all variants are manually selected (if variants exist)
+    const variantCount = selectedProduct.variants?.length || 0;
+    if (variantCount > 0) {
+      const allSelected = selectedProduct.variants.every((_, idx) => Boolean(selectedVariantImages[idx]));
+      if (!allSelected) {
+        alert("Please select an option for all variants before adding to cart.");
+        return;
+      }
+    }
+
     // Ensure user ID is set in cart
     const userId = currentUser.id || currentUser._id;
     if (userId) {
@@ -125,7 +130,7 @@ export default function ProductPage() {
       // Include a structured list of selected variants for clarity in the cart
       selectedVariants: (selectedProduct.variants || []).map((variant, idx) => ({
         name: variant.name,
-        image: selectedVariantImages[idx] || getProductImageUrl(variant.images?.[0] || ""),
+        image: selectedVariantImages[idx],
       })),
       stock: selectedProduct.stock,
     };


### PR DESCRIPTION
Disable automatic variant image selection and enforce manual selection before adding to cart.

The previous implementation automatically pre-selected the first image of each variant and allowed adding to cart without explicit user selection. This PR ensures that users must manually select an image for all variants before the product can be added to the cart.

---
<a href="https://cursor.com/background-agent?bcId=bc-439357e6-8285-4780-8be5-b18bc6367708">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-439357e6-8285-4780-8be5-b18bc6367708">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

