### PR TITLE
Fix the sidebar component

### DIFF
--- a/Archphaze/src/supplier/Suppliersidebar.jsx
+++ b/Archphaze/src/supplier/Suppliersidebar.jsx
@@ -64,20 +64,45 @@ const sections = [
   },
 ];
 
-export default function Suppliersidebar() {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Suppliersidebar({ sidebarOpen, setSidebarOpen }) {
+  // Support both controlled (via props) and uncontrolled (internal state) modes
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = typeof sidebarOpen === "boolean" && typeof setSidebarOpen === "function";
+  const isOpen = isControlled ? sidebarOpen : internalOpen;
   const location = useLocation();
   const activePath = location.pathname;
 
-  const toggleSidebar = () => setIsOpen(!isOpen);
+  const toggleSidebar = () => {
+    if (isControlled) {
+      setSidebarOpen(!sidebarOpen);
+    } else {
+      setInternalOpen(!internalOpen);
+    }
+  };
+
+  const handleItemClick = () => {
+    if (isControlled) {
+      setSidebarOpen(false);
+    } else {
+      setInternalOpen(false);
+    }
+  };
 
   return (
     <>
       {/* Sidebar */}
       <div
         className={`sticky top-24 z-30 h-[calc(100vh-96px)] w-64 bg-white shadow-md border-r p-4 overflow-auto hide-scrollbar
-          transform transition-transform duration-300 ease-in-out
-          ${isOpen ? "translate-x-0" : "-translate-x-full"} md:translate-x-0`}
+          ${
+            // Only apply slide-in/out transforms when operating in uncontrolled (self-managed) mode.
+            // In controlled mode, parents typically animate their own <aside>, so duplicating transforms
+            // here would cause the content to slide away even when the container is visible.
+            isControlled
+              ? ""
+              : `transform transition-transform duration-300 ease-in-out ${
+                  isOpen ? "translate-x-0" : "-translate-x-full"
+                } md:translate-x-0`
+          }`}
       >
         {sections.map((section, index) => (
           <div key={index} className="mb-6">
@@ -99,7 +124,7 @@ export default function Suppliersidebar() {
                     badge={item.badge}
                     children={item.children}
                     active={isActive}
-                    onClick={() => setIsOpen(false)}
+                    onClick={handleItemClick}
                   />
                 );
               })}
@@ -108,19 +133,21 @@ export default function Suppliersidebar() {
         ))}
       </div>
 
-      {/* Toggle button - top right for mobile */}
-      <div className="md:hidden fixed top-24 right-0 z-40">
-        <button
-          onClick={toggleSidebar}
-          className="m-2 p-2 rounded-md bg-white shadow-md border"
-          aria-label="Toggle sidebar"
-        >
-          {isOpen ? <FiX size={20} /> : <FiMenu size={20} />}
-        </button>
-      </div>
+      {/* Toggle button - top right for mobile (only in uncontrolled mode) */}
+      {!isControlled && (
+        <div className="md:hidden fixed top-24 right-0 z-40">
+          <button
+            onClick={toggleSidebar}
+            className="m-2 p-2 rounded-md bg-white shadow-md border"
+            aria-label="Toggle sidebar"
+          >
+            {isOpen ? <FiX size={20} /> : <FiMenu size={20} />}
+          </button>
+        </div>
+      )}
 
-      {/* Mobile Overlay */}
-      {isOpen && (
+      {/* Mobile Overlay (only in uncontrolled mode) */}
+      {!isControlled && isOpen && (
         <div
           onClick={toggleSidebar}
           className="fixed inset-0 bg-black opacity-30 z-20 md:hidden"


### PR DESCRIPTION
Make `Suppliersidebar` support controlled and uncontrolled modes to prevent double-transform issues.

The sidebar previously applied its own slide transforms, which caused a "double-translate" bug when a parent component was already animating its containing `<aside>` element. This change allows parents to control the sidebar's visibility and animation, avoiding the conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-d068cff8-c97d-467f-abf6-3850cb96df91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d068cff8-c97d-467f-abf6-3850cb96df91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

